### PR TITLE
[Highlight] Support size prefix for %t formatting specifications

### DIFF
--- a/SystemVerilog.sublime-syntax
+++ b/SystemVerilog.sublime-syntax
@@ -1049,7 +1049,7 @@ contexts:
         - match: |
             (?x)%
             (-?\d+)?                     # minimum field width
-            [bBcCdDeEfFgGhHoOpPsSuUxXzZ]   # conversion type
+            [bBcCdDeEfFgGhHoOpPsStTuUxXzZ]   # conversion type
           scope: constant.other.placeholder.systemverilog
         - match: |
             (?x)%
@@ -1057,7 +1057,7 @@ contexts:
             (\.-?\d+)?   # precision
             [eEfFgG]     # conversion type
           scope: constant.other.placeholder.float.systemverilog
-        - match: '%[lLmMtTvV%]'
+        - match: '%[lLmMvV%]'
           scope: constant.other.placeholder.systemverilog
         - match: "%"
           scope: invalid.illegal.placeholder.systemverilog


### PR DESCRIPTION
This PR support size prefix for `%t` in strings. So strings that contain `%0t` formatting specification can be parsed correctly.