### PR TITLE
Add option to disable alignment in module binding autocompletion

### DIFF
--- a/SystemVerilog.sublime-settings
+++ b/SystemVerilog.sublime-settings
@@ -19,17 +19,18 @@
 	"sv.tooltip_show_refs" : true, // True to show reference to module/interface/...
 	"sv.tooltip_show_signal_links" : false, // True to show links to driver/reference for signals
 	// SystemVerilog Alignment configuration
-	"sv.one_bind_per_line"     : true,  // When aligning module instantiation force only one binding per line
-	"sv.one_decl_per_line"     : false, // When aligning signal declaration force only one signal per line
-	"sv.max_line_length"       : 120,   // Use by alignment plugin to split one line into multiple if too long
-	"sv.strip_empty_line"      : true,  // Strip empty line inside Module declaration/alignement
-	"sv.mod_import_same_line"  : false, // When aligning module declaration, put import statement on same line as module
-	"sv.alignment_ignore_tick" : false, // Ignore line identation for every line starting with `ifdef,`elsif,...
-	"sv.align_comma_semicolon" : true,  // Align comma/semi-colon for signal/port declaration
-	"sv.align_paren"           : true,  // Align closing parenthesis for module instance
-	"sv.align_group_decl"      : false, // Group declaration separated by empty line or comments
-	"sv.param_port_alignment"  : true,  // Control if parameters/ports binding are align together
-	"sv.align_space_bind"      : false, // Add space after a port binding in module instantiation
+	"sv.one_bind_per_line"       : true,  // When aligning module instantiation force only one binding per line
+	"sv.one_decl_per_line"       : false, // When aligning signal declaration force only one signal per line
+	"sv.max_line_length"         : 120,   // Use by alignment plugin to split one line into multiple if too long
+	"sv.strip_empty_line"        : true,  // Strip empty line inside Module declaration/alignment
+	"sv.mod_import_same_line"    : false, // When aligning module declaration, put import statement on same line as module
+	"sv.alignment_ignore_tick"   : false, // Ignore line indentation for every line starting with `ifdef,`elsif,...
+	"sv.align_comma_semicolon"   : true,  // Align comma/semi-colon for signal/port declaration
+	"sv.align_paren"             : true,  // Align closing parenthesis for module instance
+	"sv.align_group_decl"        : false, // Group declaration separated by empty line or comments
+	"sv.param_port_alignment"    : true,  // Control if parameters/ports binding are align together
+	"sv.align_space_bind"        : false, // Add space after a port binding in module instantiation
+	"sv.align_binding_completion": true,  // Align port and parameter bindings in module instantiation autocompletion
 	// SystemVerilog always block completion configuration
 	"sv.clk_name"           : "clk",    // Default clock name
 	"sv.rst_name"           : "rst",    // Default reset active high

--- a/verilog_completion.py
+++ b/verilog_completion.py
@@ -806,7 +806,8 @@ class VerilogAutoComplete(sublime_plugin.EventListener):
         eot = verilogutil.clean_comment(txt_raw[pos:])
         has_binding = re.match(r'^\.\w*\b',eot) is not None
         if not has_binding:
-            is_last = re.match(r'(?s)^\.\w*\s*(?:\([^\)]+\))?\s*\)\s*(;|\w+)',eot,flags=re.MULTILINE) is not None
+            is_last = len(set([p['name'] for p in l]) - set(b)) <= 1 and \
+                re.match(r'(?s)^\.\w*\s*(?:\([^\)]+\))?\s*\)\s*(;|\w+)?',eot,flags=re.MULTILINE) is not None
         # print('End text = \n{0}\nHas_binding={1}, is_last={2}'.format(eot,has_binding,is_last))
         for x in l:
             if x['name'] not in b:
@@ -818,7 +819,9 @@ class VerilogAutoComplete(sublime_plugin.EventListener):
                     def_val = x['name']
                 s = x['name']
                 if not has_binding:
-                    s = s.ljust(len_port)+'(${0:' + def_val + '})'
+                    if self.settings.get("sv.align_binding_completion", True):
+                        s = s.ljust(len_port)
+                    s = s+'(${0:' + def_val + '})'
                     if not is_last:
                         s = s+','
                 c.append(sublime.CompletionItem(x['name'],tips,s,kind=MYKIND_FIELD, completion_format=1))


### PR DESCRIPTION
Defaults to `true` to retain backward compatibility.

Motivation: I dislike the alignment of module bindings when using autocompletion of ports and parameters.

I also noticed that the comma was not getting appended when the port/parameter being added was at the end of the list (only in the middle on the `master` branch -- and never on the `dev` branch... something changed that made the RegExp no longer match when setting `is_last`).

This PR changes the `is_last` logic to check whether all but one ports/parameters have already been inserted _and_ the cursor is at the end of the list. In other words, `is_last` is `True` _iff_ it is truly the last. This helps a great deal with Verilog's picky no-trailing-comma requirement.