### PR TITLE
Remove anchor for attributes

### DIFF
--- a/SystemVerilog.sublime-syntax
+++ b/SystemVerilog.sublime-syntax
@@ -317,7 +317,7 @@ contexts:
       captures:
         1: punctuation.definition.comment.systemverilog
     # Attributes
-    - match: ^\s*(\(\*)\s*\w
+    - match: (\(\*)\s*\w
       captures:
         1: punctuation.definition.attribute.systemverilog
       push:


### PR DESCRIPTION
<img width="1666" height="122" alt="CleanShot 2025-08-24 at 13 45 46@2x" src="https://github.com/user-attachments/assets/4803a732-8611-46a6-a783-4932893d3d57" />

It appears that attributes can find themselves within assignment statements in valid SystemVerilog, so highlighting them requires removing the need to not be prefaced by whitespace.