### PR TITLE
[Completion] fix missing space after 'if' in always* completions

### DIFF
--- a/verilog_completion.py
+++ b/verilog_completion.py
@@ -1101,11 +1101,11 @@ class VerilogHelper():
             if always_label :
                 a_l +=  ' : proc_$1'
         a_l +=  '\n'
-        a_l += 'if(~'+rst_n_name + ') begin\n'
+        a_l += 'if (~'+rst_n_name + ') begin\n'
         a_l += '$1 <= 0;'
         a_l += '\nend else '
         if clk_en_name != '':
-            a_l += 'if(' + clk_en_name + ') '
+            a_l += 'if (' + clk_en_name + ') '
         a_l+= 'begin\n'
         if not always_one_cursor:
             a_l += '$1 <= $2;'
@@ -1120,7 +1120,7 @@ class VerilogHelper():
                 a_nr +=  ' : proc_$1'
         a_nr +=  '\n'
         if clk_en_name != '':
-            a_nr += 'if(' + clk_en_name + ') begin\n'
+            a_nr += 'if (' + clk_en_name + ') begin\n'
         a_nr += '$1'
         if not always_one_cursor:
             a_nr += ' <= $2'


### PR DESCRIPTION
Hi, thank you for this cool plugin! It has been a great help to my work.
I made a fix that a missing space is added in this completion.

``` SystemVerilog
always_ff @(posedge clk or negedge rst_n) begin : proc_
    if(~rst_n) begin
//    ^ space is added here
         <= 0;
    end else begin

    end
end
```