### PR TITLE
[Highlight] fix syntax highlight when using 'automatic' keyword

### DIFF
--- a/SystemVerilog.sublime-syntax
+++ b/SystemVerilog.sublime-syntax
@@ -597,10 +597,11 @@ contexts:
 
   # Block definition
   module-def:
-    - match: '\s*(module)\s+\b({{id}})\b'
+    - match: '\b(module)\s+(?:(static|automatic)\s+)?\b({{id}})\b'
       captures:
         1: keyword.control.systemverilog
-        2: entity.name.type.module.systemverilog
+        2: keyword.other.lifetime.systemverilog
+        3: entity.name.type.module.systemverilog
       set: [module-body , module-port]
   module-port:
     - meta_scope: meta.module.port.systemverilog
@@ -638,10 +639,11 @@ contexts:
     - include: general
 
   interface-def:
-    - match: '\s*(interface)\s+\b({{id}})\b'
+    - match: '\b(interface)\s+(?:(static|automatic)\s+)?\b({{id}})\b'
       captures:
         1: keyword.other.systemverilog
-        2: entity.name.type.interface.systemverilog
+        2: keyword.other.lifetime.systemverilog
+        3: entity.name.type.interface.systemverilog
       set: [interface-body , interface-port]
   interface-port:
     - meta_scope: meta.interface.port.systemverilog

--- a/SystemVerilog.sublime-syntax
+++ b/SystemVerilog.sublime-syntax
@@ -280,7 +280,7 @@ contexts:
       scope: meta.definition.systemverilog
       captures:
         1: keyword.other.systemverilog
-        2: keyword.other.systemverilog
+        2: keyword.other.lifetime.systemverilog
         3: entity.name.type.class.systemverilog
     - match: \s*\b(automatic|cell|config|deassign|defparam|design|disable|endconfig|endgenerate|endspecify|endtable|generate|iff|ifnone|incdir|instance|liblist|library|macromodule|noshowcancelled|pulsestyle_onevent|pulsestyle_ondetect|showcancelled|specify|specparam|table|use)\b
       captures:
@@ -390,9 +390,9 @@ contexts:
     - include: constants
     - include: strings
     - include: nettype
-    - match: '^\s*(?:(static)\s+)?(?:(var|wire)\s+)?(({{id}})\s*(::)\s*)?({{id}})\s+{{id}}'
+    - match: '^\s*(?:(static|automatic)\s+)?(?:(var|wire)\s+)?(({{id}})\s*(::)\s*)?({{id}})\s+{{id}}'
       captures:
-        1: keyword.other.static.systemverilog
+        1: keyword.other.lifetime.systemverilog
         2: storage.type.net.systemverilog
         4: support.type.scope.systemverilog
         5: keyword.operator.scope.systemverilog


### PR DESCRIPTION
Hi,
This PR fixes syntax highlighting in some 'automatic' keyword related context.
For example

``` SystemVerilog
module automatic test_mod;
    task test();
        automatic test_pkg::cls obj;
    endtask
endmodule
```
Before:
<img width="401" height="96" alt="sv-before" src="https://github.com/user-attachments/assets/58fccfa1-39e0-4773-bba8-c3c49ecd7013" />

After:
<img width="403" height="101" alt="sv-after" src="https://github.com/user-attachments/assets/8f8eb03c-ad8b-423a-81e0-ac83e6d24e00" />
